### PR TITLE
Add configuration via JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# PrePress Digi
+
+This project automates the launching of Adobe applications when new files are dropped into a watch directory.  
+Paths were previously hard coded in `config.py`.  Configuration is now handled through a small JSON file or environment variables.
+
+## Configuration
+
+1. Copy `config.json` and edit the values to match your environment.  
+   You can also set environment variables with the same names if you prefer.
+   * `watch_folder` – folder that will be monitored for new files.
+   * `script_template` – path to the JSX template used by Illustrator.
+   * `temp_script` – location where Illustrator will read the generated JSX file.
+   * `illustrator_exe` – full path to the Illustrator executable.
+2. Optionally set `PDP_CONFIG_FILE` to point to a different JSON file.
+3. Each individual value may be overridden with environment variables named in upper case. For example `WATCH_FOLDER` overrides `watch_folder` from the JSON file.
+
+Environment variables inside values (e.g. `%APPDATA%`) are expanded automatically.
+
+## Running
+
+After configuring, run `main.py` to install the script and start watching for new files:
+
+```bash
+python main.py
+```

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "watch_folder": "C:\\path\\to\\watch_folder",
+  "script_template": "Scripts/check_and_export.jsx",
+  "temp_script": "%APPDATA%\\Roaming\\Adobe\\Illustrator Script Runner\\run_this.jsx",
+  "illustrator_exe": "\"C:\\Program Files\\Adobe\\Adobe Illustrator 2025\\Support Files\\Contents\\Windows\\Illustrator.exe\""
+}

--- a/config.py
+++ b/config.py
@@ -1,16 +1,53 @@
 import os
+import json
+
+
+CONFIG_FILE = os.getenv(
+    "PDP_CONFIG_FILE",
+    os.path.join(os.path.dirname(__file__), "config.json"),
+)
+
+
+def _load_config(path: str) -> dict:
+    if os.path.exists(path):
+        with open(path, "r") as fh:
+            return json.load(fh)
+    return {}
+
+
+_CONFIG_DATA = _load_config(CONFIG_FILE)
+
+
+def _get_config(key: str, default: str) -> str:
+    value = os.getenv(key.upper(), _CONFIG_DATA.get(key, default))
+    if isinstance(value, str):
+        value = os.path.expandvars(value)
+    return value
+
 
 # Folder to watch
-WATCH_FOLDER = r"C:\Users\Benjamin\Desktop\PrePressDigi\watch_folder"
+WATCH_FOLDER = _get_config(
+    "watch_folder", os.path.join(os.getcwd(), "watch_folder")
+)
 
 # Path to your Illustrator script template
-SCRIPT_TEMPLATE = os.path.join(os.getcwd(), "Scripts", "check_and_export.jsx")
+SCRIPT_TEMPLATE = _get_config(
+    "script_template", os.path.join(os.getcwd(), "Scripts", "check_and_export.jsx")
+)
 
 # Location to copy script that Illustrator auto-loads
-TEMP_SCRIPT = os.path.expandvars(r"%APPDATA%\Roaming\Adobe\Illustrator Script Runner\run_this.jsx")
+TEMP_SCRIPT = _get_config(
+    "temp_script",
+    os.path.expandvars(
+        r"%APPDATA%\Roaming\Adobe\Illustrator Script Runner\run_this.jsx"
+    ),
+)
 
 # Adobe app you want to trigger
-ILLUSTRATOR_EXE = r'"C:\Program Files\Adobe\Adobe Illustrator 2025\Support Files\Contents\Windows\Illustrator.exe"'
+ILLUSTRATOR_EXE = _get_config(
+    "illustrator_exe",
+    r'"C:\Program Files\Adobe\Adobe Illustrator 2025\Support Files\Contents\Windows\Illustrator.exe"',
+)
 
 # File types and apps
 PROGRAM_MAP = {
@@ -20,3 +57,4 @@ PROGRAM_MAP = {
     ".psd": "Photoshop",
     ".pdf": "Acrobat"
 }
+


### PR DESCRIPTION
## Summary
- allow overriding file paths with a JSON configuration or environment variables
- add `config.json` template
- document the new configuration process

## Testing
- `python -m py_compile config.py bridge_runner.py watcher.py installer.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68470e1d05588327bf8a6aadd5cfb55f