### PR TITLE
Fix Illustrator path quoting

### DIFF
--- a/bridge_runner.py
+++ b/bridge_runner.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
-from config import ILLUSTRATOR_EXE  # ✅ You need to import this or define it here
+# Import the Illustrator executable path as a raw string
+from config import ILLUSTRATOR_EXE
 
 def run_illustrator_script_with_file(ai_file_path):
     jsx_template_path = os.path.join("Scripts", "run_this.jsx")
@@ -19,6 +20,7 @@ def run_illustrator_script_with_file(ai_file_path):
 
     try:
         # Open the file in Illustrator (so user can manually run the script via File > Scripts)
+        # Pass the executable path directly without extra quoting
         subprocess.run([ILLUSTRATOR_EXE, ai_file_path], check=True)
 
         print("Illustrator opened the file. Run 'File > Scripts > run_this' inside Illustrator to complete automation.")

--- a/config.py
+++ b/config.py
@@ -10,7 +10,9 @@ SCRIPT_TEMPLATE = os.path.join(os.getcwd(), "Scripts", "check_and_export.jsx")
 TEMP_SCRIPT = os.path.expandvars(r"%APPDATA%\Roaming\Adobe\Illustrator Script Runner\run_this.jsx")
 
 # Adobe app you want to trigger
-ILLUSTRATOR_EXE = r'"C:\Program Files\Adobe\Adobe Illustrator 2025\Support Files\Contents\Windows\Illustrator.exe"'
+# Provide the raw path without surrounding quotes so ``subprocess`` can
+# receive it directly.
+ILLUSTRATOR_EXE = r"C:\Program Files\Adobe\Adobe Illustrator 2025\Support Files\Contents\Windows\Illustrator.exe"
 
 # File types and apps
 PROGRAM_MAP = {


### PR DESCRIPTION
## Summary
- fix ILLUSTRATOR_EXE quoting
- clarify comment on raw path usage in `bridge_runner.py`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684711844f0083278cb52ddbf70561f1