### PR TITLE
Auto-run Illustrator script

### DIFF
--- a/bridge_runner.py
+++ b/bridge_runner.py
@@ -18,9 +18,8 @@ def run_illustrator_script_with_file(ai_file_path):
         file.write(jsx_code)
 
     try:
-        # Open the file in Illustrator (so user can manually run the script via File > Scripts)
-        subprocess.run([ILLUSTRATOR_EXE, ai_file_path], check=True)
-
-        print("Illustrator opened the file. Run 'File > Scripts > run_this' inside Illustrator to complete automation.")
+        # Launch Illustrator and execute the generated script directly
+        subprocess.run([ILLUSTRATOR_EXE, "-cmd", temp_script_path], check=True)
+        print("Illustrator executed the script automatically.")
     except Exception as e:
-        print("Failed to open file in Illustrator:", e)
+        print("Failed to run Illustrator script:", e)

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ SCRIPT_TEMPLATE = os.path.join(os.getcwd(), "Scripts", "check_and_export.jsx")
 TEMP_SCRIPT = os.path.expandvars(r"%APPDATA%\Roaming\Adobe\Illustrator Script Runner\run_this.jsx")
 
 # Adobe app you want to trigger
-ILLUSTRATOR_EXE = r'"C:\Program Files\Adobe\Adobe Illustrator 2025\Support Files\Contents\Windows\Illustrator.exe"'
+ILLUSTRATOR_EXE = r"C:\Program Files\Adobe\Adobe Illustrator 2025\Support Files\Contents\Windows\Illustrator.exe"
 
 # File types and apps
 PROGRAM_MAP = {


### PR DESCRIPTION
## Summary
- run Illustrator JSX directly through the `-cmd` flag
- keep `ILLUSTRATOR_EXE` without embedded quotes

## Testing
- `python -m py_compile bridge_runner.py config.py watcher.py installer.py main.py`
- `w3m -dump "https://duckduckgo.com/?q=illustrator+command+line+run+jsx" | head -n 3` *(fails: SSL error)*

------
https://chatgpt.com/codex/tasks/task_e_684732a141908327b269c1296637d0ce